### PR TITLE
Removing extraction file and getting format function in ogg decoding

### DIFF
--- a/pkg/lunii/utils.go
+++ b/pkg/lunii/utils.go
@@ -120,12 +120,6 @@ func convertSliceToInt16Slice(mySlice []float32) []int16 {
 }
 
 func GetByteSlice(r io.Reader) ([]byte, *oggvorbis.Format, error) {
-	var format *oggvorbis.Format
-	format, err := oggvorbis.GetFormat(r)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	oggAudio, format, err := oggvorbis.ReadAll(r)
 	if err != nil {
 		return nil, nil, errors.New("Could not decode ogg file?")

--- a/pkg/lunii/writer.go
+++ b/pkg/lunii/writer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -228,26 +227,7 @@ func convertAndWriteAudio(reader zip.ReadCloser, deviceAudioDirectory string, au
 		} else if extension == "ogg" {
 			// it's an ogg file
 
-			// Didn't work for the moment with the file open with the zip.ReadCloser. So save a temp file and use it.
-			tmpFile, err := os.CreateTemp("", "")
-			if err != nil {
-				return err
-			}
-			defer tmpFile.Close()
-			defer os.Remove(tmpFile.Name())
-
-			if _, err := io.Copy(tmpFile, file); err != nil {
-				tmpFile.Close()
-				return err
-			}
-
-			tmpFile.Close()
-			tmpFile, err = os.Open(tmpFile.Name())
-			if err != nil {
-				return err
-			}
-
-			mp3, err = OggToMp3(tmpFile)
+			mp3, err = OggToMp3(file)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
I have found how to avoid extracting the ogg file before decoding.